### PR TITLE
Added missing columns in the blockheaders table

### DIFF
--- a/src/db/sql/blockheaders_table.sql
+++ b/src/db/sql/blockheaders_table.sql
@@ -8,5 +8,18 @@ CREATE TABLE IF NOT EXISTS blockheaders (
     nonce VARCHAR(78) NOT NULL,
     transaction_root CHAR(66),
     receipts_root CHAR(66),
-    state_root CHAR(66)
+    state_root CHAR(66),
+    parent_hash VARCHAR(66),
+    miner VARCHAR(42),
+    logs_bloom VARCHAR(1024),
+    difficulty VARCHAR(78),
+    totalDifficulty VARCHAR(78),
+    sha3_uncles VARCHAR(66),
+    timestamp VARCHAR(100),  
+    extra_data VARCHAR(1024), 
+    mix_hash VARCHAR(66),
+    withdrawals_root VARCHAR(66),
+    blob_gas_used VARCHAR(78),
+    excess_blob_gas VARCHAR(78),
+    parent_beacon_block_root VARCHAR(66)
     );

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -45,6 +45,32 @@ pub struct BlockHeaderWithEmptyTransaction {
     pub state_root: String,
     #[serde(rename(deserialize = "transactionsRoot"))]
     pub transactions_root: String,
+    #[serde(rename(deserialize = "parentHash"))]
+    pub parent_hash: Option<String>,
+    #[serde(rename(deserialize = "miner"))]
+    pub miner: Option<String>,
+    #[serde(rename(deserialize = "logsBloom"))]
+    pub logs_bloom: Option<String>,
+    #[serde(rename(deserialize = "difficulty"))]
+    pub difficulty: Option<String>,
+    #[serde(rename(deserialize = "totalDifficulty"))]
+    pub total_difficulty: Option<String>,
+    #[serde(rename(deserialize = "sha3Uncles"))]
+    pub sha3_uncles: Option<String>,
+    #[serde(rename(deserialize = "timestamp"))]
+    pub timestamp: String,
+    #[serde(rename(deserialize = "extraData"))]
+    pub extra_data: Option<String>,
+    #[serde(rename(deserialize = "mixHash"))]
+    pub mix_hash: Option<String>,
+    #[serde(rename(deserialize = "withdrawalsRoot"))]
+    pub withdrawals_root: Option<String>,
+    #[serde(rename(deserialize = "blobGasUsed"))]
+    pub blob_gas_used: Option<String>,
+    #[serde(rename(deserialize = "excessBlobGas"))]
+    pub excess_blob_gas: Option<String>,
+    #[serde(rename(deserialize = "parentBeaconBlockRoot"))]
+    pub parent_beacon_block_root: Option<String>
 }
 
 #[derive(Debug, Deserialize)]
@@ -65,6 +91,32 @@ pub struct BlockHeaderWithFullTransaction {
     #[serde(rename(deserialize = "transactionsRoot"))]
     pub transactions_root: String,
     pub transactions: Vec<Transaction>,
+    #[serde(rename(deserialize = "parentHash"))]
+    pub parent_hash: Option<String>,
+    #[serde(rename(deserialize = "miner"))]
+    pub miner: Option<String>,
+    #[serde(rename(deserialize = "logsBloom"))]
+    pub logs_bloom: Option<String>,
+    #[serde(rename(deserialize = "difficulty"))]
+    pub difficulty: Option<String>,
+    #[serde(rename(deserialize = "totalDifficulty"))]
+    pub total_difficulty: Option<String>,
+    #[serde(rename(deserialize = "sha3Uncles"))]
+    pub sha3_uncles: Option<String>,
+    #[serde(rename(deserialize = "timestamp"))]
+    pub timestamp: String,
+    #[serde(rename(deserialize = "extraData"))]
+    pub extra_data: Option<String>,
+    #[serde(rename(deserialize = "mixHash"))]
+    pub mix_hash: Option<String>,
+    #[serde(rename(deserialize = "withdrawalsRoot"))]
+    pub withdrawals_root: Option<String>,
+    #[serde(rename(deserialize = "blobGasUsed"))]
+    pub blob_gas_used: Option<String>,
+    #[serde(rename(deserialize = "excessBlobGas"))]
+    pub excess_blob_gas: Option<String>,
+    #[serde(rename(deserialize = "parentBeaconBlockRoot"))]
+    pub parent_beacon_block_root: Option<String>
 }
 
 #[derive(Clone, Debug, sqlx::FromRow)]


### PR DESCRIPTION
Added Missing columns in the blockheaders table:
1. parent_hash
2. miner
3. logs_bloom
4. difficulty
5. totalDifficulty
6. sha3_uncles
7. timestamp
8. extra_data
9. mix_hash
10. withdrawals_root
11. blob_gas_used
12. excess_blob_gas
13. parent_beacon_block_root