### PR TITLE
chore: dockerize fossil headers service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Multistage build
+FROM rust:1.81 AS builder
+
+WORKDIR /usr/app
+COPY . .
+RUN cargo build --release
+
+# Use a distroless docker image which should further reduce the size.
+# This one is setup specifically for rust.
+FROM gcr.io/distroless/cc-debian12
+WORKDIR /usr/app
+COPY --from=builder /usr/app/target/release/fossil_headers_db .
+
+EXPOSE 8080
+# defaults to update mode
+CMD ["/usr/app/fossil_headers_db", "update"]


### PR DESCRIPTION
Make a simple dockerization of the fossil headers service, in the update mode. 

If we want other modes or even specific parameters, we can modify the docker image to accept them.


I believe ideally we should have the indexer running constantly instead of currently being invoke once in a while.